### PR TITLE
Moved hterm import before index.js

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -54,10 +54,12 @@
         </div><!-- /.modal-dialog -->
     </div><!-- /.modal -->
 
-    <!-- NOTE: Jquery import should come first. Since bootstrap uses jquery -->
+    <!-- NOTE: jQuery import should come first. Since Bootstrap uses jQuery -->
     <script src="bower_components/jquery/dist/jquery.min.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
-    <script src="js/index.js"></script>
+
+    <!-- NOTE: hterm import should come first. Since index.js uses hterm -->
     <script src="js/lib/hterm_all.js"></script>
+    <script src="js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
In your most recent commit (3244878) you updated index.html by moved `hterm_all.js` after `index.js`. However, `index.js` calls one of hterm's methods so hterm must must be loaded first in the HTML file.