### PR TITLE
Remove unnecessary grunt-vulcanize

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,6 @@
     "grunt": "^1.0.1",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-jscs": "^3.0.1",
-    "grunt-vulcanize": "^1.0.0"
+    "grunt-jscs": "^3.0.1"
   }
 }


### PR DESCRIPTION
Now we don't use polymer, we should remove `grunt-vulcanize` from `package.json`