### PR TITLE
Autofocus on `connect` button at start

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -103,6 +103,7 @@
 
     <!-- NOTE: hterm import should come first. Since index.js uses hterm -->
     <script src="js/lib/hterm_all.min.js"></script>
+    <script src="js/draw_ui.js"></script>
     <script src="js/index.js"></script>
 </body>
 </html>

--- a/app/js/draw_ui.js
+++ b/app/js/draw_ui.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, Sungguk Lim. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+function DrawUi() {}
+
+DrawUi.prototype = {
+  ShowSettingsDialog: function() {
+    $('#settingsModal').modal('show');
+  },
+
+  /**
+   * Called when Hterm terminmal is finished to load.
+   * Every ui configuration(e.g. foo_button.focus() should be in here)
+   */
+  OnHtermReady: function() {
+    $('.modal-footer button').focus();
+    this.registerCloseBtnEvent_();
+  },
+
+  /**
+   * @private
+   */
+  registerCloseBtnEvent_: function() {
+    var connectBtn = document.querySelector('#connectBtn');
+    connectBtn.addEventListener('click', function(event) {
+      // Get the serial port (i.e. COM1, COM2, COM3, etc.)
+      var portSelect = document.querySelector('#portDropdown');
+      var port = portSelect.options[portSelect.selectedIndex].value;
+
+      // Get the baud rate (i.e. 9600, 38400, 57600, 115200, etc. )
+      var baudSelect = document.querySelector('#bitrateDropdown');
+      var bitrate = Number(baudSelect.options[baudSelect.selectedIndex].value);
+
+      // Get the data bit (i.e. "seven" or "eight")
+      var databitSelect = document.querySelector('#databitDropdown');
+      var databit = databitSelect.options[databitSelect.selectedIndex].value;
+
+      // Get the parity bit (i.e. "no", "odd", or "even")
+      var paritySelect = document.querySelector('#parityDropdown');
+      var parity = paritySelect.options[paritySelect.selectedIndex].value;
+
+      // Get the stop bit (i.e. "one" or "two")
+      var stopbitSelect = document.querySelector('#stopbitDropdown');
+      var stopbit = stopbitSelect.options[stopbitSelect.selectedIndex].value;
+
+      // Get the flow control value (i.e. true or false)
+      var fcSelect = document.querySelector('#flowControlDropdown');
+      var flowControlValue = fcSelect.options[fcSelect.selectedIndex].value;
+      var flowControl = (flowControlValue === 'true');
+
+      // Format is ...
+      // settings = Object {bitrate: 14400, dataBits: "eight", parityBit: "odd",
+      // stopBits: "two", ctsFlowControl: true}
+      var settings = {
+        bitrate: bitrate,
+        dataBits: databit,
+        parityBit: parity,
+        stopBits: stopbit,
+        ctsFlowControl: flowControl
+      };
+
+      chrome.storage.local.set(settings);
+
+      chrome.serial.connect(port, {
+        'bitrate': settings.bitrate,
+        'dataBits': settings.dataBits,
+        'parityBit': settings.parityBit,
+        'stopBits': settings.stopBits,
+        'ctsFlowControl': settings.ctsFlowControl
+      }, function(openInfo) {
+        if (openInfo === undefined) {
+          inputOutput.println('Unable to connect to device with value' +
+              settings.toString());
+          // TODO: Open 'connection dialog' again.
+          return;
+        }
+
+        inputOutput.println('Device found on ' + port +
+                  ' via Connection ID ' + openInfo.connectionId);
+        self.connectionId = openInfo.connectionId;
+        AddConnectedSerialId(openInfo.connectionId);
+        chrome.serial.onReceive.addListener(function(info) {
+          if (info && info.data) {
+            inputOutput.print(ab2str(info.data));
+          }
+        });
+      });
+    });
+  }
+};

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 $('#settingsModal').on('shown.bs.modal', function() {
   $('connectBtn').focus();
-})
+});
 
 /*
  *  Utility functions

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -5,13 +5,11 @@
 var inputOutput;
 var self;
 
-document.addEventListener('DOMContentLoaded', function() {
-  $('#settingsModal').modal('show');
-}, false);
+var UI_INSTANCE = new DrawUi();
 
-$('#settingsModal').on('shown.bs.modal', function() {
-  $('connectBtn').focus();
-});
+document.addEventListener('DOMContentLoaded', function() {
+  UI_INSTANCE.ShowSettingsDialog();
+}, false);
 
 /*
  *  Utility functions
@@ -149,79 +147,8 @@ window.onload = function() {
   t.decorate(document.querySelector('#terminal'));
 
   t.onTerminalReady = function() {
+    UI_INSTANCE.OnHtermReady();
     t.runCommandClass(Crosh, document.location.hash.substr(1));
     return true;
   };
 };
-
-// Closes the settings dialog
-var connectBtn = document.querySelector('#connectBtn');
-connectBtn.addEventListener('click', function(event) {
-  // If |inputOutput| is null, it means hterm is not ready yet.
-  if (!inputOutput) {
-    return;
-  }
-
-  // Get the serial port (i.e. COM1, COM2, COM3, etc.)
-  var portElement = document.querySelector('#portDropdown');
-  var port = portElement.options[portElement.selectedIndex].value;
-
-  // Get the baud rate (i.e. 9600, 38400, 57600, 115200, etc. )
-  var baudElement = document.querySelector('#bitrateDropdown');
-  var bitrate = Number(baudElement.options[baudElement.selectedIndex].value);
-
-  // Get the data bit (i.e. "seven" or "eight")
-  var databitElement = document.querySelector('#databitDropdown');
-  var databit = databitElement.options[databitElement.selectedIndex].value;
-
-  // Get the parity bit (i.e. "no", "odd", or "even")
-  var paritybitElement = document.querySelector('#parityDropdown');
-  var parity = paritybitElement.options[paritybitElement.selectedIndex].value;
-
-  // Get the stop bit (i.e. "one" or "two")
-  var stopbitElement = document.querySelector('#stopbitDropdown');
-  var stopbit = stopbitElement.options[stopbitElement.selectedIndex].value;
-
-  // Get the flow control value (i.e. true or false)
-  var fcElement = document.querySelector('#flowControlDropdown');
-  var flowControlValue = fcElement.options[fcElement.selectedIndex].value;
-  var flowControl = (flowControlValue === 'true');
-
-  // Format is ...
-  // settings = Object {bitrate: 14400, dataBits: "eight", parityBit: "odd",
-  // stopBits: "two", ctsFlowControl: true}
-  var settings = {
-    bitrate: bitrate,
-    dataBits: databit,
-    parityBit: parity,
-    stopBits: stopbit,
-    ctsFlowControl: flowControl
-  };
-
-  chrome.storage.local.set(settings);
-
-  chrome.serial.connect(port, {
-    'bitrate': settings.bitrate,
-    'dataBits': settings.dataBits,
-    'parityBit': settings.parityBit,
-    'stopBits': settings.stopBits,
-    'ctsFlowControl': settings.ctsFlowControl
-  }, function(openInfo) {
-    if (openInfo === undefined) {
-      inputOutput.println('Unable to connect to device with value' +
-          settings.toString());
-      // TODO: Open 'connection dialog' again.
-      return;
-    }
-
-    inputOutput.println('Device found on ' + port +
-              ' via Connection ID ' + openInfo.connectionId);
-    self.connectionId = openInfo.connectionId;
-    AddConnectedSerialId(openInfo.connectionId);
-    chrome.serial.onReceive.addListener(function(info) {
-      if (info && info.data) {
-        inputOutput.print(ab2str(info.data));
-      }
-    });
-  });
-});

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -9,6 +9,10 @@ document.addEventListener('DOMContentLoaded', function() {
   $('#settingsModal').modal('show');
 }, false);
 
+$('#settingsModal').on('shown.bs.modal', function() {
+  $('connectBtn').focus();
+})
+
 /*
  *  Utility functions
  *


### PR DESCRIPTION
Until now `connect` button doesn't have focus by default at start. This sucks because we always have to use 'mouse' to click it. After this patch we can just press `Enter` to connect(if we don't change options).

- Set autofocus on 'connect' button at start.
- Create draw_ui.js and move some UI related codes.

TEST=Load app. See all option select is working well.

@RandomlyKnighted  When you can find time.